### PR TITLE
Add support for flag parameters in descriptions

### DIFF
--- a/spring-shell2-core/src/main/java/org/springframework/shell2/ParameterDescription.java
+++ b/spring-shell2-core/src/main/java/org/springframework/shell2/ParameterDescription.java
@@ -47,9 +47,16 @@ public class ParameterDescription {
 	private String formal;
 
 	/**
-	 * A string representation of the default value for the parameter, if any.
+	 * A string representation of the default value (if the option is left out entirely) for the parameter, if any.
 	 */
 	private Optional<String> defaultValue = Optional.empty();
+
+	/**
+	 * A string representation of the default value for this parameter, if it can be used as a mere flag (<em>e.g.</em>
+	 * {@literal --force} without a value, being an equivalent to {@literal --force true}).
+	 * <p>{@literal Optional.empty()} (the default) means that this parameter cannot be used as a flag.</p>
+	 */
+	private Optional<String> defaultValueWhenFlag = Optional.empty();
 
 	/**
 	 * The list of 'keys' that can be used to specify this parameter, if any.
@@ -99,6 +106,11 @@ public class ParameterDescription {
 		return this;
 	}
 
+	public ParameterDescription whenFlag(String defaultValue) {
+		this.defaultValueWhenFlag = Optional.of(defaultValue);
+		return this;
+	}
+
 	public ParameterDescription keys(List<String> keys) {
 		this.keys = keys;
 		return this;
@@ -108,6 +120,7 @@ public class ParameterDescription {
 		this.mandatoryKey = mandatoryKey;
 		return this;
 	}
+
 
 	public String type() {
 		return type;
@@ -119,6 +132,10 @@ public class ParameterDescription {
 
 	public String help() {
 		return help;
+	}
+
+	public Optional<String> defaultValueWhenFlag() {
+		return defaultValueWhenFlag;
 	}
 
 	public ParameterDescription formal(String formal) {

--- a/spring-shell2-samples/src/main/java/org/springframework/shell2/samples/standard/Commands.java
+++ b/spring-shell2-samples/src/main/java/org/springframework/shell2/samples/standard/Commands.java
@@ -36,9 +36,9 @@ public class Commands {
 
 	}
 
-	@ShellMethod(help = "it's better")
-	public void foobar() {
-
+	@ShellMethod(help = "Shows support for boolean parameters, with arity=0")
+	public void shutdown(@ShellOption(arity = 0) boolean force) {
+		System.out.println("You passed " + force);
 	}
 
 	@ShellMethod(help = "something else")

--- a/spring-shell2-shell1-adapter/src/test/java/org/springframework/shell2/legacy/LegacyCommands.java
+++ b/spring-shell2-shell1-adapter/src/test/java/org/springframework/shell2/legacy/LegacyCommands.java
@@ -56,7 +56,10 @@ public class LegacyCommands implements CommandMarker {
 	}
 
 	@CliCommand(value = "sum", help = "adds two numbers")
-	public int sum(@CliOption(key = "v1", unspecifiedDefaultValue = "38") int a, @CliOption(key = "v2", specifiedDefaultValue = "42") int b) {
+	public int sum(
+		@CliOption(key = "v1", unspecifiedDefaultValue = "38") int a,
+		@CliOption(key = "v2", specifiedDefaultValue = "42") int b
+	) {
 		return a + b;
 	}
 	
@@ -68,7 +71,7 @@ public class LegacyCommands implements CommandMarker {
 	@CliCommand(value = "someMethod", help = "Method used for testing purposes")
 	public String someMethod(
 			@CliOption(key = "key", mandatory = false, help = "The optional parameter") String parameter,
-			@CliOption(key = "option", help = "an option", specifiedDefaultValue = "true", unspecifiedDefaultValue = "false", mandatory = true) boolean option) {
+			@CliOption(key = "option", help = "an option", specifiedDefaultValue = "true", unspecifiedDefaultValue = "false") boolean option) {
 		return parameter + ", " + option;
 	}
 	

--- a/spring-shell2-shell1-adapter/src/test/java/org/springframework/shell2/legacy/LegacyParameterResolverTest.java
+++ b/spring-shell2-shell1-adapter/src/test/java/org/springframework/shell2/legacy/LegacyParameterResolverTest.java
@@ -179,7 +179,8 @@ public class LegacyParameterResolverTest {
 		
 		assertThat(description.keys()).containsExactly("--option");
 		assertThat(description.formal()).isEqualTo(boolean.class.getName());
-		assertThat(description.defaultValue().get()).isEqualTo("false, or true if used as --option");
+		assertThat(description.defaultValue().get()).isEqualTo("false");
+		assertThat(description.defaultValueWhenFlag().get()).isEqualTo("true");
 		assertThat(description.mandatoryKey()).isTrue();
 		
 		String expectedHelp = methodParameter.getParameterAnnotation(CliOption.class).help();
@@ -194,7 +195,8 @@ public class LegacyParameterResolverTest {
 		
 		assertThat(description.keys()).containsExactly("--v2");
 		assertThat(description.formal()).isEqualTo(int.class.getName());
-		assertThat(description.defaultValue().get()).isEqualTo("42 if used as --v2");
+		assertThat(description.defaultValue().get()).isEqualTo("null");
+		assertThat(description.defaultValueWhenFlag().get()).isEqualTo("42");
 		assertThat(description.mandatoryKey()).isTrue();
 		
 		String expectedHelp = methodParameter.getParameterAnnotation(CliOption.class).help();


### PR DESCRIPTION
Fixes #55

Promoted the concept of default value when used as a flag to the core.
Changed `help` command accordingly