### PR TITLE
AttributedCharSequenceResultHandler uses Terminal

### DIFF
--- a/spring-shell2-core/src/main/java/org/springframework/shell2/result/AttributedCharSequenceResultHandler.java
+++ b/spring-shell2-core/src/main/java/org/springframework/shell2/result/AttributedCharSequenceResultHandler.java
@@ -40,6 +40,6 @@ public class AttributedCharSequenceResultHandler implements ResultHandler<Attrib
 
 	@Override
 	public void handleResult(AttributedCharSequence result) {
-		System.out.println(result.toAnsi(terminal));
+		terminal.writer().println(result.toAnsi(terminal));
 	}
 }


### PR DESCRIPTION
Use Terminal::writer instead of the System.out directly.

Fixes #59