### PR TITLE
Support line continuation

### DIFF
--- a/spring-shell2-core/src/main/java/org/springframework/shell2/JLineShell.java
+++ b/spring-shell2-core/src/main/java/org/springframework/shell2/JLineShell.java
@@ -148,7 +148,10 @@ public class JLineShell implements Shell {
 			MethodTarget methodTarget = null;
 			int c = 0;
 			int wordsUsedForCommandKey = 0;
-			for (String word : lineReader.getParsedLine().words()) {
+			List<String> words = lineReader.getParsedLine().words();
+			words = sanitizeInput(words);
+
+			for (String word : words) {
 				c++;
 				candidateCommand.append(separator).append(word);
 				MethodTarget t = methodTargets.get(candidateCommand.toString());
@@ -159,9 +162,6 @@ public class JLineShell implements Shell {
 				separator = " ";
 			}
 
-			List<String> words = lineReader.getParsedLine().words();
-			// TODO investigate trailing empty string in e.g. "help 'WTF 2'"
-			words = words.stream().filter(w -> w.length() > 0).collect(Collectors.toList());
 			if (methodTarget != null) {
 				List<String> wordsForArgs = words.subList(wordsUsedForCommandKey, words.size());
 				Method method = methodTarget.getMethod();
@@ -183,6 +183,19 @@ public class JLineShell implements Shell {
 				System.out.println("No command found for " + words);
 			}
 		}
+	}
+
+	/**
+	 * Sanitize the buffer input given the customizations applied to the JLine parser (<em>e.g.</em> support for
+	 * line continuations, <em>etc.</em>)
+	 */
+	private List<String> sanitizeInput(List<String> words) {
+		words = words.stream()
+			.map(s -> s.replaceAll("^\\n+|\\n+$", "")) // CR at beginning/end of line introduced by backslash continuation
+			.map(s -> s.replaceAll("\\n+", " ")) // CR in middle of word introduced by return inside a quoted string
+			.filter(w -> w.length() > 0) // Empty word introduced when using quotes, no idea why...
+			.collect(Collectors.toList());
+		return words;
 	}
 
 	private void validateArgs(Object[] args, MethodTarget methodTarget) {

--- a/spring-shell2-core/src/main/java/org/springframework/shell2/JLineShell.java
+++ b/spring-shell2-core/src/main/java/org/springframework/shell2/JLineShell.java
@@ -96,6 +96,10 @@ public class JLineShell implements Shell {
 			methodTargets.putAll(resolver.resolve());
 		}
 
+		DefaultParser parser = new DefaultParser();
+		parser.setEofOnUnclosedQuote(true);
+		parser.setEofOnEscapedNewLine(true);
+
 		LineReaderBuilder lineReaderBuilder = LineReaderBuilder.builder()
 				.terminal(terminal)
 				.appName("Foo")
@@ -120,7 +124,7 @@ public class JLineShell implements Shell {
 						}
 					}
 				})
-				.parser(new DefaultParser());
+				.parser(parser);
 
 		lineReader = lineReaderBuilder.build();
 

--- a/spring-shell2-core/src/main/java/org/springframework/shell2/MyDefaultParser.java
+++ b/spring-shell2-core/src/main/java/org/springframework/shell2/MyDefaultParser.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.shell2;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+import org.jline.reader.EOFError;
+import org.jline.reader.ParsedLine;
+import org.jline.reader.Parser;
+
+public class MyDefaultParser implements Parser {
+
+    private char[] quoteChars = {'\'', '"'};
+
+    private char[] escapeChars = {'\\'};
+
+    private boolean eofOnUnclosedQuote;
+
+    private boolean eofOnEscapedNewLine;
+
+    public void setQuoteChars(final char[] chars) {
+		this.quoteChars = chars;
+    }
+
+    public char[] getQuoteChars() {
+        return this.quoteChars;
+    }
+
+    public void setEscapeChars(final char[] chars) {
+        this.escapeChars = chars;
+    }
+
+    public char[] getEscapeChars() {
+        return this.escapeChars;
+    }
+
+    public void setEofOnUnclosedQuote(boolean eofOnUnclosedQuote) {
+        this.eofOnUnclosedQuote = eofOnUnclosedQuote;
+    }
+
+    public boolean isEofOnUnclosedQuote() {
+        return eofOnUnclosedQuote;
+    }
+
+    public void setEofOnEscapedNewLine(boolean eofOnEscapedNewLine) {
+        this.eofOnEscapedNewLine = eofOnEscapedNewLine;
+    }
+
+    public boolean isEofOnEscapedNewLine() {
+        return eofOnEscapedNewLine;
+    }
+
+    public ParsedLine parse(final String line, final int cursor, ParseContext context) {
+        List<String> words = new LinkedList<>();
+        StringBuilder current = new StringBuilder();
+        int wordCursor = -1;
+        int wordIndex = -1;
+        int quoteStart = -1;
+
+        for (int i = 0; (line != null) && (i < line.length()); i++) {
+            // once we reach the cursor, set the
+            // position of the selected index
+            if (i == cursor) {
+                wordIndex = words.size();
+                // the position in the current argument is just the
+                // length of the current argument
+                wordCursor = current.length();
+            }
+
+            if (quoteStart < 0 && isQuoteChar(line, i)) {
+                // Start a quote block
+                quoteStart = i;
+            } else if (quoteStart >= 0) {
+                // In a quote block
+                if (line.charAt(quoteStart) == line.charAt(i) && !isEscaped(line, i)) {
+                    // End the block; arg could be empty, but that's fine
+                    words.add(current.toString());
+                    current.setLength(0);
+                    quoteStart = -1;
+                } else if (!isEscapeChar(line, i)) {
+                    // Take the next character
+                    current.append(line.charAt(i));
+                }
+            } else {
+                // Not in a quote block
+                if (isDelimiter(line, i)) {
+                    if (current.length() > 0) {
+                        words.add(current.toString());
+                        current.setLength(0); // reset the arg
+                    }
+                } else if (!isEscapeChar(line, i)) {
+                    current.append(line.charAt(i));
+                }
+            }
+        }
+
+        if (current.length() > 0 || cursor == line.length()) {
+            words.add(current.toString());
+        }
+
+        if (cursor == line.length()) {
+            wordIndex = words.size() - 1;
+            wordCursor = words.get(words.size() - 1).length();
+        }
+
+        String lastWord = words.get(words.size() - 1);
+        if (eofOnEscapedNewLine && isEscapeChar(line, line.length() - 1)) {
+            words.set(words.size() - 1, lastWord.substring(0, lastWord.length()-1));
+            throw new EOFError(-1, -1, "Escaped new line", "newline");
+        }
+        if (eofOnUnclosedQuote && quoteStart >= 0) {
+            words.set(words.size() - 1, lastWord.substring(0, lastWord.length()-1));
+            throw new EOFError(-1, -1, "Missing closing quote", line.charAt(quoteStart) == '\''
+                    ? "quote" : "dquote");
+        }
+
+        return new ArgumentList(line, words, wordIndex, wordCursor, cursor);
+    }
+
+    /**
+     * Returns true if the specified character is a whitespace parameter. Check to ensure that the character is not
+     * escaped by any of {@link #getQuoteChars}, and is not escaped by ant of the {@link #getEscapeChars}, and
+     * returns true from {@link #isDelimiterChar}.
+     *
+     * @param buffer    The complete command buffer
+     * @param pos       The index of the character in the buffer
+     * @return          True if the character should be a delimiter
+     */
+    public boolean isDelimiter(final CharSequence buffer, final int pos) {
+        return !isQuoted(buffer, pos) && !isEscaped(buffer, pos) && isDelimiterChar(buffer, pos);
+    }
+
+    public boolean isQuoted(final CharSequence buffer, final int pos) {
+        return false;
+    }
+
+    public boolean isQuoteChar(final CharSequence buffer, final int pos) {
+        if (pos < 0) {
+            return false;
+        }
+
+        for (int i = 0; (quoteChars != null) && (i < quoteChars.length); i++) {
+            if (buffer.charAt(pos) == quoteChars[i]) {
+                return !isEscaped(buffer, pos);
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if this character is a valid escape char (i.e. one that has not been escaped)
+     */
+    public boolean isEscapeChar(final CharSequence buffer, final int pos) {
+        if (pos < 0) {
+            return false;
+        }
+
+        for (int i = 0; (escapeChars != null) && (i < escapeChars.length); i++) {
+            if (buffer.charAt(pos) == escapeChars[i]) {
+                return !isEscaped(buffer, pos); // escape escape
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if a character is escaped (i.e. if the previous character is an escape)
+     *
+     * @param buffer
+     *          the buffer to check in
+     * @param pos
+     *          the position of the character to check
+     * @return true if the character at the specified position in the given buffer is an escape character and the character immediately preceding it is not an
+     *         escape character.
+     */
+    public boolean isEscaped(final CharSequence buffer, final int pos) {
+        if (pos <= 0) {
+            return false;
+        }
+
+        return isEscapeChar(buffer, pos - 1);
+    }
+
+    /**
+     * Returns true if the character at the specified position if a delimiter. This method will only be called if
+     * the character is not enclosed in any of the {@link #getQuoteChars}, and is not escaped by ant of the
+     * {@link #getEscapeChars}. To perform escaping manually, override {@link #isDelimiter} instead.
+     */
+    public boolean isDelimiterChar(CharSequence buffer, int pos) {
+        return Character.isWhitespace(buffer.charAt(pos));
+    }
+
+    /**
+     * The result of a delimited buffer.
+     *
+     * @author <a href="mailto:mwp1@cornell.edu">Marc Prud'hommeaux</a>
+     */
+    public static class ArgumentList implements ParsedLine
+    {
+        private final String line;
+
+        private final List<String> words;
+
+        private final int wordIndex;
+
+        private final int wordCursor;
+
+        private final int cursor;
+
+        public ArgumentList(final String line, final List<String> words, final int wordIndex, final int wordCursor, final int cursor) {
+            this.line = line;
+            this.words = Collections.unmodifiableList(Objects.requireNonNull(words));
+            this.wordIndex = wordIndex;
+            this.wordCursor = wordCursor;
+            this.cursor = cursor;
+        }
+
+        public int wordIndex() {
+            return this.wordIndex;
+        }
+
+        public String word() {
+            // TODO: word() should always be contained in words()
+            if ((wordIndex < 0) || (wordIndex >= words.size())) {
+                return "";
+            }
+            return words.get(wordIndex);
+        }
+
+        public int wordCursor() {
+            return this.wordCursor;
+        }
+
+        public List<String> words() {
+            return this.words;
+        }
+
+        public int cursor() {
+            return this.cursor;
+        }
+
+        public String line() {
+            return line;
+        }
+
+    }
+
+}


### PR DESCRIPTION
- either by ending a line with backslash and hitting return  
- or but hitting return while inside quotes

Fixes #23

Not sure this is the best approach, but seems to work.

Interesting things to note:
- When you've hit enter and are on a subsequent line, you can't do TAB completion anymore (it just inserts a tab)
- did not apply sanitising in the completer, but this doesn't seem to be necessary.

Additional testing looking for edge cases welcome.